### PR TITLE
✨ feat(changelog): add header struct for changelog format

### DIFF
--- a/src/change_log.rs
+++ b/src/change_log.rs
@@ -1,3 +1,4 @@
+mod header;
 mod section;
 mod tag;
 
@@ -9,15 +10,7 @@ use section::Section;
 use tag::Tag;
 use thiserror::Error;
 
-const DEFAULT_HEADER: &str = r##"
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-"##;
+use crate::change_log::header::Header;
 
 const DEFAULT_FOOTER: &str = r##""##;
 
@@ -40,7 +33,7 @@ pub struct ChangeLog<'a> {
     repository: &'a Repository,
     owner: String,
     repo: String,
-    header: String,
+    header: Header,
     sections: Vec<Section>,
     links: String,
     footer: String,
@@ -68,7 +61,7 @@ impl<'a> ChangeLog<'a> {
             repository,
             owner,
             repo,
-            header: DEFAULT_HEADER.to_string(),
+            header: Header::default(),
             footer: DEFAULT_FOOTER.to_string(),
             links: String::new(),
             sections: Vec::default(),
@@ -94,11 +87,11 @@ impl<'a> ChangeLog<'a> {
         Ok((owner, repo))
     }
 
-    /// set header
-    pub fn set_header(&mut self, value: &str) -> &mut Self {
-        self.header = value.to_string();
-        self
-    }
+    // /// set header
+    // pub fn set_header(&mut self, value: &str) -> &mut Self {
+    //     self.header = value.to_string();
+    //     self
+    // }
 
     /// set footer
     pub fn set_footer(&mut self, value: &str) -> &mut Self {

--- a/src/change_log/header.rs
+++ b/src/change_log/header.rs
@@ -1,0 +1,36 @@
+use std::fmt::Display;
+
+const DEFAULT_TITLE: &str = "Changelog";
+
+const DEFAULT_PARAGRAPHS: [&str; 2] = [
+    "All notable changes to this project will be documented in this file.",
+    "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).",
+];
+
+#[derive(Debug)]
+pub(crate) struct Header {
+    title: String,
+    paragraphs: Vec<String>,
+}
+
+impl Default for Header {
+    fn default() -> Self {
+        let title = String::from(DEFAULT_TITLE);
+        let mut paragraphs = Vec::new();
+        for paragraph in DEFAULT_PARAGRAPHS {
+            paragraphs.push(paragraph.to_string());
+        }
+        Self { title, paragraphs }
+    }
+}
+
+impl Display for Header {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "# {}", self.title)?;
+        for para in self.paragraphs.iter() {
+            writeln!(f)?;
+            writeln!(f, "{para}")?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
- replace DEFAULT_HEADER string with Header struct for improved code organization
- update ChangeLog struct to use Header type instead of String
- comment out set_header method in favor of Header struct's default method