### PR TITLE
♻️ refactor(change_log): update walk setup naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💄 style(change_log)-reorder imports for readability(pr [#16])
 - ♻️ refactor(tag)-improve semver extraction logic(pr [#22])
 - ♻️ refactor(change_log)-restructure ChangeLog and builder pattern(pr [#23])
+- ♻️ refactor(change_log)-update walk setup naming(pr [#28])
 
 ### Fixed
 
@@ -67,3 +68,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#25]: https://github.com/jerus-org/gen-changelog/pull/25
 [#26]: https://github.com/jerus-org/gen-changelog/pull/26
 [#27]: https://github.com/jerus-org/gen-changelog/pull/27
+[#28]: https://github.com/jerus-org/gen-changelog/pull/28

--- a/src/change_log.rs
+++ b/src/change_log.rs
@@ -208,11 +208,10 @@ impl ChangeLogBuilder {
                 let next_tag = peekable_tags.peek();
 
                 if let Some(next_tag) = next_tag {
-                    let setup = WalkSetup::FromTagtoTag(tag, next_tag);
+                    let setup = WalkSetup::FromReleaseToRelease(tag, next_tag);
                     section.walk_repository(setup, repository, &mut revwalk)?;
                 } else {
                     let setup = WalkSetup::ReleaseToStart(tag);
-
                     section.walk_repository(setup, repository, &mut revwalk)?;
                 }
             }


### PR DESCRIPTION
- rename `FromTagtoTag` to `FromReleaseToRelease` for clarity
- add `get_commits` method to handle commit retrieval
- enhance logging for clearer debugging information