### PR TITLE
🐛 fix(config): correct heading index initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🐛 config: correct typo in module import(pr [#18])
 - 🐛 change_log: correct changelog section placement(pr [#41])
+- 🐛 config: correct heading index initialization(pr [#43])
 
 [#3]: https://github.com/jerus-org/gen-changelog/pull/3
 [#4]: https://github.com/jerus-org/gen-changelog/pull/4
@@ -97,3 +98,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#40]: https://github.com/jerus-org/gen-changelog/pull/40
 [#41]: https://github.com/jerus-org/gen-changelog/pull/41
 [#42]: https://github.com/jerus-org/gen-changelog/pull/42
+[#43]: https://github.com/jerus-org/gen-changelog/pull/43

--- a/src/config/heading_mgmt.rs
+++ b/src/config/heading_mgmt.rs
@@ -13,7 +13,7 @@ pub(crate) trait HeadingMgmt {
 
 impl HeadingMgmt for BTreeMap<u8, String> {
     fn add_heading(&mut self, group: &str) -> &mut Self {
-        let i = self.len() as u8;
+        let i = self.len() as u8 + 1; // order from 1
         if i == u8::MAX {
             log::warn!("maximum number of groups created ({})", u8::MAX);
             self


### PR DESCRIPTION
- increment heading index by 1 to start order from 1
- ensure proper numbering for group headings in BTreeMap