### PR TITLE
♻️ refactor(cc_commit): change return type of kind_string method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(section)-modify section structure and initialization(pr [#44])
 - ♻️ refactor(change_log)-streamline commit reporting logic(pr [#45])
 - ♻️ refactor(change_log)-simplify commit classification(pr [#46])
+- ♻️ refactor(cc_commit)-change return type of kind_string method(pr [#47])
 
 ### Fixed
 
@@ -105,3 +106,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#44]: https://github.com/jerus-org/gen-changelog/pull/44
 [#45]: https://github.com/jerus-org/gen-changelog/pull/45
 [#46]: https://github.com/jerus-org/gen-changelog/pull/46
+[#47]: https://github.com/jerus-org/gen-changelog/pull/47

--- a/src/change_log/section.rs
+++ b/src/change_log/section.rs
@@ -130,9 +130,10 @@ impl Section {
 
     pub(crate) fn add_commit(&mut self, summary: Option<&str>, message: Option<&str>) -> &mut Self {
         let conventional_commit = ConvCommit::new(summary, message);
-        let class = ChangeLogClass::new(&conventional_commit.kind_string());
-
-        self.add_commit_to_hashmap(&class.to_string(), conventional_commit.clone());
+        if let Some(k) = conventional_commit.kind_string() {
+            let class = ChangeLogClass::new(&k);
+            self.add_commit_to_hashmap(&class.to_string(), conventional_commit.clone());
+        }
 
         self
     }

--- a/src/change_log/section/cc_commit.rs
+++ b/src/change_log/section/cc_commit.rs
@@ -81,8 +81,8 @@ impl ConvCommit {
         self.kind.is_some()
     }
 
-    pub(crate) fn kind_string(&self) -> String {
-        self.kind.clone().unwrap_or_default()
+    pub(crate) fn kind_string(&self) -> Option<String> {
+        self.kind.clone()
     }
 
     pub(crate) fn title_as_string(&self) -> String {


### PR DESCRIPTION
- change return type of kind_string from String to Option<String>
- enable handling of cases where kind is not present