### PR TITLE
♻️ refactor(cc_commit): remove unused title_as_string function

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ♻️ refactor(cc_commit)-change return type of kind_string method(pr [#47])
 - Add-update_pcu-parameter-to-config(pr [#48])
 - ♻️ refactor(change_log)-improve section header handling(pr [#49])
+- ♻️ refactor(cc_commit)-remove unused title_as_string function(pr [#50])
 
 ### Fixed
 
@@ -111,3 +112,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#47]: https://github.com/jerus-org/gen-changelog/pull/47
 [#48]: https://github.com/jerus-org/gen-changelog/pull/48
 [#49]: https://github.com/jerus-org/gen-changelog/pull/49
+[#50]: https://github.com/jerus-org/gen-changelog/pull/50

--- a/src/change_log/section.rs
+++ b/src/change_log/section.rs
@@ -245,7 +245,7 @@ impl Section {
                 "### {heading}\n\n{}\n",
                 commits
                     .iter()
-                    .map(|c| format!(" - {}\n", c.title_as_string()))
+                    .map(|c| format!(" - {c}\n"))
                     .collect::<String>()
             ))
         }

--- a/src/change_log/section/cc_commit.rs
+++ b/src/change_log/section/cc_commit.rs
@@ -84,19 +84,6 @@ impl ConvCommit {
     pub(crate) fn kind_string(&self) -> Option<String> {
         self.kind.clone()
     }
-
-    pub(crate) fn title_as_string(&self) -> String {
-        format!(
-            "{}{}{}{}: {}",
-            self.emoji.clone().unwrap_or_default(),
-            self.kind.clone().unwrap_or_default(),
-            self.scope
-                .as_ref()
-                .map_or("".to_string(), |s| format!("({s})")),
-            if self.breaking { "!" } else { "" },
-            self.title,
-        )
-    }
 }
 
 impl std::fmt::Display for ConvCommit {


### PR DESCRIPTION
- delete title_as_string method from ConvCommit as it is no longer used