### PR TITLE
👷 ci(circleci): fix variable casing in release command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ commands:
                 ;;
             esac
 
-            cargo release version $BUMP \
+            cargo release version $bump \
                 --execute
             cargo release replace \
                 --execute

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 👷 ci(circleci)-update cargo release and changelog process(pr [#75])
 - 👷 ci(circleci)-add bump version variable to cargo release command(pr [#76])
 - 👷 ci(circleci)-simplify pipefail setting in commands(pr [#77])
+- 👷 ci(circleci)-fix variable casing in release command(pr [#78])
 
 ## [0.0.1] - 2025-09-08
 
@@ -173,5 +174,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#75]: https://github.com/jerus-org/gen-changelog/pull/75
 [#76]: https://github.com/jerus-org/gen-changelog/pull/76
 [#77]: https://github.com/jerus-org/gen-changelog/pull/77
+[#78]: https://github.com/jerus-org/gen-changelog/pull/78
 [Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/jerus-org/gen-changelog/releases/tag/v0.0.1


### PR DESCRIPTION
- change variable $BUMP to lowercase $bump to match script requirements