### PR TITLE
🔧 chore(release): update pre-release replacements in release.toml

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 👷 ci(circleci)-simplify pipefail setting in commands(pr [#77])
 - 👷 ci(circleci)-fix variable casing in release command(pr [#78])
 - 👷 ci(circleci)-enhance cargo release commands with verbosity(pr [#79])
+- 🔧 chore(release)-update pre-release replacements in release.toml(pr [#80])
 
 ## [0.0.1] - 2025-09-08
 
@@ -177,5 +178,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#77]: https://github.com/jerus-org/gen-changelog/pull/77
 [#78]: https://github.com/jerus-org/gen-changelog/pull/78
 [#79]: https://github.com/jerus-org/gen-changelog/pull/79
+[#80]: https://github.com/jerus-org/gen-changelog/pull/80
 [Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.1...HEAD
 [0.0.1]: https://github.com/jerus-org/gen-changelog/releases/tag/v0.0.1

--- a/release.toml
+++ b/release.toml
@@ -1,5 +1,5 @@
 pre-release-replacements = [
-    { file = "docs/lib.md", search = """gen-change = "\\d+.\\d+.\\d+"""", replace = "{{crate_name}} = \"{{version}}\"", exactly = 1 },
+    { file = "docs/lib.md", search = """gen-changelog = "\\d+.\\d+.\\d+"""", replace = "{{crate_name}} = \"{{version}}\"", exactly = 1 },
     { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
     { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
     { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },


### PR DESCRIPTION
- correct search term from "gen-change" to "gen-changelog" in docs/lib.md
- ensure accurate versioning replacements during release process