### PR TITLE
👷 ci(circleci): add gen-changelog installation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,6 +242,10 @@ jobs:
           condition: << parameters.when_update_pcu >>
           steps:
             - toolkit/install_latest_pcu
+      - run:
+          name: install gen-changelog (me)
+          command: |
+            cargo install --path .
       - when:
           condition:
             and:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "gen-changelog"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gen-changelog"
 description = """Generate a change log based on the git commits compatible
 with keep-a-changelog and using conventional commits to categorise commits."""
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
 edition = "2024"
 rust-version = "1.85"

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2] - 2025-09-09
+
 ### Changed
 
 - 💄 style(Cargo)-reorder authors in Cargo.toml(pr [#74])

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- 👷 ci(circleci)-add gen-changelog installation step(pr [#81])
+
 ## [0.0.2] - 2025-09-09
 
 ### Changed
@@ -181,5 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#78]: https://github.com/jerus-org/gen-changelog/pull/78
 [#79]: https://github.com/jerus-org/gen-changelog/pull/79
 [#80]: https://github.com/jerus-org/gen-changelog/pull/80
-[Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.1...HEAD
+[#81]: https://github.com/jerus-org/gen-changelog/pull/81
+[Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/jerus-org/gen-changelog/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/jerus-org/gen-changelog/releases/tag/v0.0.1


### PR DESCRIPTION
- include command to install gen-changelog using cargo in CI pipeline
- ensure changelog generation tool is available for automated tasks