### PR TITLE
Bump-version-to-0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "gen-changelog"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gen-changelog"
 description = """Generate a change log based on the git commits compatible
 with keep-a-changelog and using conventional commits to categorise commits."""
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Jeremiah Russell <jrussell@jerus.ie>"]
 edition = "2024"
 rust-version = "1.85"

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5] - 2025-09-09
+
 ### Changed
 
 - 👷 ci(circleci)-enhance release command with changelog generation(pr [#83])
@@ -202,7 +204,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#82]: https://github.com/jerus-org/gen-changelog/pull/82
 [#83]: https://github.com/jerus-org/gen-changelog/pull/83
 [#84]: https://github.com/jerus-org/gen-changelog/pull/84
-[Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.4...HEAD
+[Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.5...HEAD
+[0.0.5]: https://github.com/jerus-org/gen-changelog/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/jerus-org/gen-changelog/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/jerus-org/gen-changelog/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/jerus-org/gen-changelog/compare/v0.0.1...v0.0.2

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or by configuring the dependencies in `Cargo.toml`
 
 ```toml
 [dependencies]
-gen-changelog = "0.0.4"
+gen-changelog = "0.0.5"
 ```
 
 ## Gen-changelog executable documentation 

--- a/docs/lib.md
+++ b/docs/lib.md
@@ -15,6 +15,6 @@ or by configuring the dependencies in `Cargo.toml`
 
 ```toml
 [dependencies]
-gen-changelog = "0.0.4"
+gen-changelog = "0.0.5"
 ```
 


### PR DESCRIPTION
- update gen-changelog version from 0.0.4 to 0.0.5 in Cargo.toml example