### PR TITLE
✨ feat(cli): integrate clap for command-line parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +284,8 @@ name = "gen-changelog"
 version = "0.0.6"
 dependencies = [
  "chrono",
+ "clap",
+ "clap-verbosity-flag",
  "env_logger",
  "git2",
  "lazy-regex",
@@ -282,6 +334,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
@@ -809,6 +867,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ include = [
 
 [dependencies]
 chrono = { version = "0.4.41", features = ["alloc"] }
+clap = { version = "4.5.47", features = ["derive"] }
+clap-verbosity-flag = "3.0.4"
 env_logger = "0.11.8"
 git2 = "0.20.2"
 lazy-regex = "3.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,20 @@
 use std::path::PathBuf;
 
+use clap::Parser;
 use gen_changelog::{ChangeLog, ChangeLogConfig};
 use git2::Repository;
 
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(flatten)]
+    logging: clap_verbosity_flag::Verbosity,
+}
+
 fn main() {
-    let mut logging = get_logging(log::LevelFilter::Debug);
+    let args = Cli::parse();
+
+    let mut logging = get_logging(args.logging.log_level_filter());
     logging.init();
 
     let repo_dir = PathBuf::new().join(".");


### PR DESCRIPTION
- add clap and related packages to Cargo.lock
- include clap-verbosity-flag, clap_builder, clap_derive, clap_lex
- add heck and strsim packages for enhanced functionality