### PR TITLE
✨ feat(lib): export DisplaySections from change_log_config

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ add subcommand support for configuration(pr [#89])
 - ✨ enhance error handling and command options(pr [#91])
 - ✨ enhance changelog config with serde support(pr [#93])
+- ✨ export DisplaySections from change_log_config(pr [#94])
 
 ### Changed
 
@@ -233,6 +234,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#91]: https://github.com/jerus-org/gen-changelog/pull/91
 [#92]: https://github.com/jerus-org/gen-changelog/pull/92
 [#93]: https://github.com/jerus-org/gen-changelog/pull/93
+[#94]: https://github.com/jerus-org/gen-changelog/pull/94
 [Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.6...HEAD
 [0.0.6]: https://github.com/jerus-org/gen-changelog/compare/v0.0.5...v0.0.6
 [0.0.5]: https://github.com/jerus-org/gen-changelog/compare/v0.0.4...v0.0.5

--- a/src/change_log_config.rs
+++ b/src/change_log_config.rs
@@ -42,8 +42,11 @@ const DEFAULT_CONFIG_FILE: &str = "gen-changelog.toml";
 #[serde(rename_all = "kebab-case")]
 pub enum DisplaySections {
     #[default]
+    /// Display all available sections
     All,
+    /// Display only the most recent section
     One,
+    /// Display the lesser of the specified number and all sections
     Custom(usize),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ mod change_log_config;
 pub use change_log::ChangeLog;
 pub use change_log::ChangeLogError;
 pub use change_log_config::ChangeLogConfig;
+pub use change_log_config::DisplaySections;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use gen_changelog::{ChangeLog, ChangeLogConfig, ChangeLogError};
+use gen_changelog::{ChangeLog, ChangeLogConfig, ChangeLogError, DisplaySections};
 use git2::Repository;
 
 #[derive(Parser, Debug)]
@@ -32,10 +32,11 @@ struct ConfigCli {
 
 impl ConfigCli {
     fn run(&self) -> Result<(), ChangeLogError> {
-        let _config = ChangeLogConfig::default();
+        let mut config = ChangeLogConfig::default();
+        config.set_display_sections(DisplaySections::Custom(3));
         if self.save {
-            // config.save()?;
-            println!("Save the default changelog configuration.")
+            log::info!("Saving the default changelog configuration.");
+            config.save()?;
         }
         Ok(())
     }
@@ -76,6 +77,7 @@ fn run(args: Cli) -> Result<(), ChangeLogError> {
         log::trace!("base config to build on: {config:?}");
 
         config.publish_group("Security");
+        config.set_display_sections(DisplaySections::Custom(3));
 
         let change_log = default_changelog_build(&repository, config);
 


### PR DESCRIPTION
- introduce DisplaySections to customize changelog display
- set display sections to custom value for better flexibility

🐛 fix(main): enable saving of changelog configuration

- fix configuration saving by uncommenting save method
- add log information for saving action