### PR TITLE
♻️ refactor(main): update error type import

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use gen_changelog::{ChangeLog, ChangeLogConfig, DisplaySections, Error as GcError};
+use gen_changelog::{ChangeLog, ChangeLogConfig, DisplaySections};
 use git2::Repository;
 
 #[derive(Parser, Debug)]
@@ -31,7 +31,7 @@ struct ConfigCli {
 }
 
 impl ConfigCli {
-    fn run(&self) -> Result<(), GcError> {
+    fn run(&self) -> Result<(), gen_changelog::Error> {
         let mut config = ChangeLogConfig::default();
         config.set_display_sections(DisplaySections::Custom(3));
         if self.save {
@@ -63,7 +63,7 @@ fn main() {
     }
 }
 
-fn run(args: Cli) -> Result<(), GcError> {
+fn run(args: Cli) -> Result<(), gen_changelog::Error> {
     if let Some(cmds) = args.command {
         match cmds {
             Commands::Configuration(config_cli) => config_cli.run()?,


### PR DESCRIPTION
- remove unused GcError import from gen_changelog
- update Result type to use gen_changelog::Error