### PR TITLE
✨ feat(changelog): add comments for changelog configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "Conv",
         "kindstring",
         "mgmt",
+        "Mygroup",
         "revwalk",
         "rtest"
     ]

--- a/PRLOG.md
+++ b/PRLOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ✨ add comments for changelog configuration(pr [#125])
+
 ### Changed
 
 - 🔧 chore(script)-update changelog generation command(pr [#124])
@@ -311,6 +315,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#122]: https://github.com/jerus-org/gen-changelog/pull/122
 [#123]: https://github.com/jerus-org/gen-changelog/pull/123
 [#124]: https://github.com/jerus-org/gen-changelog/pull/124
+[#125]: https://github.com/jerus-org/gen-changelog/pull/125
 [Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.0.8...HEAD
 [0.0.8]: https://github.com/jerus-org/gen-changelog/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/jerus-org/gen-changelog/compare/v0.0.6...v0.0.7

--- a/src/change_log.rs
+++ b/src/change_log.rs
@@ -133,12 +133,13 @@ impl ChangeLogBuilder {
 
         let mut revwalk = repository.revwalk()?;
         revwalk.set_sorting(git2::Sort::TIME)?;
+        let groups_mapping = self.config.groups_mapping();
 
         let mut current_section = Section::new(
             None,
             self.config.headings(),
             self.summary_flag,
-            self.config.groups_mapping(),
+            &groups_mapping,
         );
 
         // Case where no release has been made - no version tags
@@ -169,7 +170,7 @@ impl ChangeLogBuilder {
                     Some(tag.clone()),
                     self.config.headings(),
                     self.summary_flag,
-                    self.config.groups_mapping(),
+                    &groups_mapping,
                 );
 
                 let next_tag = peekable_tags.peek();

--- a/src/change_log_config/test_config_serialization.rs
+++ b/src/change_log_config/test_config_serialization.rs
@@ -40,10 +40,6 @@ mod integration_tests {
             "Fixed" = 2
             "Custom" = 5
 
-            [groups-mapping]
-            feat = "Added"
-            fix = "Fixed"
-
             [release-pattern]
             prefix = "v"
         "#;
@@ -57,10 +53,5 @@ mod integration_tests {
         expected_headings.insert(5, "Custom".to_string());
 
         assert_eq!(config.headings, expected_headings);
-        assert_eq!(
-            config.groups_mapping.get("feat"),
-            Some(&"Added".to_string())
-        );
-        assert_eq!(config.groups_mapping.get("fix"), Some(&"Fixed".to_string()));
     }
 }


### PR DESCRIPTION
- add comments for group tables definition and usage
- introduce comments for display order of groups and sections
- remove unnecessary group mappings field from ChangeLogConfig
- implement dynamic group mapping generation in method

♻️ refactor(change_log_config): update changelog save logic

- insert comments into TOML string before saving configuration file
- modify logic to ensure comments are added at correct positions