### PR TITLE
Add-test-logger-utility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 mod change_log;
 mod change_log_config;
 mod error;
+#[cfg(test)]
+pub(crate) mod test_utils;
 
 pub use change_log::{ChangeLog, ChangeLogBuilder};
 pub use change_log_config::ChangeLogConfig;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,8 @@
+use log::LevelFilter;
+
+pub(crate) fn get_test_logger() {
+    let mut builder = env_logger::Builder::new();
+    builder.filter(None, LevelFilter::Debug);
+    builder.format_timestamp_secs().format_module_path(false);
+    let _ = builder.try_init();
+}


### PR DESCRIPTION
- introduce get_test_logger function for testing purposes
- configure logger with debug level filtering and simplified formatting