### PR TITLE
✨ feat(cli): add name option for changelog file

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ✨ add name option for changelog file(pr [#156])
+
 ## [0.1.2] - 2025-09-26
 
 ### Changed
@@ -387,6 +393,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#153]: https://github.com/jerus-org/gen-changelog/pull/153
 [#154]: https://github.com/jerus-org/gen-changelog/pull/154
 [#155]: https://github.com/jerus-org/gen-changelog/pull/155
+[#156]: https://github.com/jerus-org/gen-changelog/pull/156
+[Unreleased]: https://github.com/jerus-org/gen-changelog/compare/v0.1.2...HEAD
 [0.1.2]: https://github.com/jerus-org/gen-changelog/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/jerus-org/gen-changelog/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/jerus-org/gen-changelog/compare/v0.0.8...v0.1.0

--- a/docs/lib.md
+++ b/docs/lib.md
@@ -192,7 +192,7 @@ fn generate_changelog() -> Result<(), Box<dyn std::error::Error>> {
         .walk_repository(&repo)?
         .build();
     
-    changelog.save()?;
+    changelog.save("CHANGELOG.md")?;
     Ok(())
 }
 ```
@@ -219,7 +219,7 @@ fn generate_custom_changelog() -> Result<(), Box<dyn std::error::Error>> {
         .walk_repository(&repo)?
         .build();
     
-    changelog.save()?;
+    changelog.save("CHANGELOG.md")?;
     Ok(())
 }
 ```
@@ -240,7 +240,7 @@ fn prepare_release(version: &str) -> Result<(), Box<dyn std::error::Error>> {
         .update_unreleased_to_next_version(Some(&version.to_string()))
         .build();
     
-    changelog.save()?;
+    changelog.save("CHANGELOG.md")?;
     Ok(())
 }
 ```

--- a/src/change_log.rs
+++ b/src/change_log.rs
@@ -18,7 +18,8 @@ use tag::Tag;
 
 use crate::{ChangeLogConfig, Error, change_log_config::DisplaySections};
 
-const CHANGELOG_FILENAME: &str = "CHANGELOG.md";
+/// default name for the file to save the changlog.
+pub const DEFAULT_CHANGELOG_FILENAME: &str = "CHANGELOG.md";
 
 /// Regular expression pattern for matching GitHub repository URLs.
 ///
@@ -111,9 +112,9 @@ impl ChangeLog {
     /// let changelog = ChangeLog::builder().build();
     /// changelog.save().expect("Failed to save changelog");
     /// ```
-    pub fn save(&self) -> Result<(), Error> {
+    pub fn save(&self, name: &str) -> Result<(), Error> {
         log::debug!("package root is `{}`", self.pkg_root.display());
-        let path = self.pkg_root.join(CHANGELOG_FILENAME);
+        let path = self.pkg_root.join(name);
         log::debug!("path to changelog is `{}`", path.display());
         std::fs::write(path, self.to_string().as_str())?;
         Ok(())
@@ -752,7 +753,7 @@ mod tests {
         std::env::set_current_dir(temp_path).unwrap();
 
         let changelog = ChangeLog::builder().build();
-        let result = changelog.save();
+        let result = changelog.save(DEFAULT_CHANGELOG_FILENAME);
 
         // Restore original directory
         std::env::set_current_dir(original_dir).unwrap();

--- a/src/change_log.rs
+++ b/src/change_log.rs
@@ -51,7 +51,7 @@ static REMOTE: Lazy<Regex> = lazy_regex!(
 ///     .build();
 ///
 /// // Save to CHANGELOG.md
-/// changelog.save().expect("Failed to save changelog");
+/// changelog.save("CHANGELOG.md").expect("Failed to save changelog");
 /// ```
 #[derive(Debug, Clone)]
 pub struct ChangeLog {
@@ -110,7 +110,7 @@ impl ChangeLog {
     /// use gen_changelog::ChangeLog;
     ///
     /// let changelog = ChangeLog::builder().build();
-    /// changelog.save().expect("Failed to save changelog");
+    /// changelog.save("CHANGELOG.md").expect("Failed to save changelog");
     /// ```
     pub fn save(&self, name: &str) -> Result<(), Error> {
         log::debug!("package root is `{}`", self.pkg_root.display());

--- a/src/generate_cli.rs
+++ b/src/generate_cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 mod package;
 
 use clap::Parser;
-use gen_changelog::{ChangeLog, ChangeLogConfig, Error};
+use gen_changelog::{ChangeLog, ChangeLogConfig, DEFAULT_CHANGELOG_FILENAME, Error};
 use git2::Repository;
 
 #[derive(Parser, Debug)]
@@ -39,7 +39,7 @@ pub(crate) struct GenerateCli {
     #[arg(short, long)]
     show: bool,
     /// name for changelog file
-    #[arg(long, default_value = "CHANGELOG.md")]
+    #[arg(long, default_value = DEFAULT_CHANGELOG_FILENAME)]
     name: String,
 }
 
@@ -80,7 +80,7 @@ impl GenerateCli {
             .build();
 
         if !self.no_save {
-            let _ = change_log.save();
+            let _ = change_log.save(&self.name);
         }
         if self.show {
             println!("{change_log}");

--- a/src/generate_cli.rs
+++ b/src/generate_cli.rs
@@ -38,6 +38,9 @@ pub(crate) struct GenerateCli {
     /// print the changelog to standard output
     #[arg(short, long)]
     show: bool,
+    /// name for changelog file
+    #[arg(long, default_value = "CHANGELOG.md")]
+    name: String,
 }
 
 impl GenerateCli {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+pub use change_log::DEFAULT_CHANGELOG_FILENAME;
 pub use change_log::{ChangeLog, ChangeLogBuilder};
 pub use change_log_config::ChangeLogConfig;
 pub use error::Error;


### PR DESCRIPTION
- introduce a new `name` option to specify the changelog file name
- set default value for `name` as "CHANGELOG.md"