### PR TITLE
fix: scope release tags to package family

### DIFF
--- a/crates/gen-changelog/src/cli/generate_cli.rs
+++ b/crates/gen-changelog/src/cli/generate_cli.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use gen_changelog::{ChangeLog, ChangeLogConfig, DEFAULT_CHANGELOG_FILENAME, Error, RustPackages};
+use gen_changelog::{
+    ChangeLog, ChangeLogConfig, DEFAULT_CHANGELOG_FILENAME, Error, ReleasePattern, RustPackages,
+};
 use git2::Repository;
 
 #[derive(Parser, Debug)]
@@ -64,13 +66,21 @@ impl GenerateCli {
             None
         };
 
-        let config = self.make_config()?;
+        let mut config = self.make_config()?;
+
+        // When targeting a specific package, treat only that package's
+        // `<package>-v*` tags as release boundaries so the workspace shadow
+        // `v*` tags do not produce duplicate/empty sections (issue #274).
+        if self.package.is_some() {
+            config.set_release_pattern(ReleasePattern::PackagePrefix("v".to_string()));
+        }
 
         let mut change_log_builder = ChangeLog::builder();
         let change_log = change_log_builder
             .with_config(config)
             .with_summary_flag(self.display_summaries)
             .with_rust_package(rust_package)
+            .with_package_name(self.package.clone())
             .walk_repository(&repository)
             .unwrap()
             .update_unreleased_to_next_version(self.next_version.as_ref())

--- a/crates/gen-changelog/src/lib/change_log.rs
+++ b/crates/gen-changelog/src/lib/change_log.rs
@@ -187,6 +187,9 @@ pub struct ChangeLogBuilder {
     links: Vec<Link>,
     /// Configuration for changelog generation
     config: ChangeLogConfig,
+    /// Name of the package being generated for, used to restrict release tags
+    /// to that package's `<package>-v*` family (issue #274).
+    package_name: Option<String>,
 }
 
 impl Debug for ChangeLogBuilder {
@@ -221,6 +224,7 @@ impl ChangeLogBuilder {
             summary_flag: bool::default(),
             include_merge_commits: bool::default(),
             config: ChangeLogConfig::default(),
+            package_name: None,
         }
     }
 
@@ -330,6 +334,22 @@ impl ChangeLogBuilder {
     /// Add the package root and dependencies to the configuration
     pub fn with_rust_package(&mut self, rust_package: Option<RustPackage>) -> &mut Self {
         self.rust_package = rust_package;
+        self
+    }
+
+    /// Sets the package name used to restrict release tags to that package's
+    /// `<package>-v*` family.
+    ///
+    /// This is required for [`ReleasePattern::PackagePrefix`] to match: the
+    /// captured package segment of each tag is compared against this name so
+    /// that only the selected package's release tags become changelog
+    /// boundaries, ignoring workspace shadow `v*` tags (issue #274). Has no
+    /// effect under the default [`ReleasePattern::Prefix`].
+    ///
+    /// [`ReleasePattern::PackagePrefix`]: crate::ReleasePattern::PackagePrefix
+    /// [`ReleasePattern::Prefix`]: crate::ReleasePattern::Prefix
+    pub fn with_package_name(&mut self, name: Option<String>) -> &mut Self {
+        self.package_name = name;
         self
     }
 
@@ -647,6 +667,9 @@ impl ChangeLogBuilder {
             let name = String::from_utf8(name.to_vec()).unwrap_or("invalid utf8".to_string());
             log::trace!("processing {name} as a tag");
             let mut tag_builder = Tag::builder(Some(id), name, repository);
+            if let Some(pkg) = &self.package_name {
+                tag_builder.set_package(pkg);
+            }
             let tag = tag_builder
                 .get_semver(self.config.release_pattern())
                 .get_date()
@@ -1141,5 +1164,99 @@ mod tests {
         assert!(output.contains("My Awesome Project"));
         assert!(output.contains("This project does amazing things"));
         assert!(output.contains("Version history below"));
+    }
+
+    /// Builds a temp git repo carrying two version-tag families at different
+    /// commits: a crate tag `gen-circleci-orb-v0.1.0` on commit A and a
+    /// workspace shadow tag `v0.1.0` on commit B. Mirrors the jerus-org
+    /// workspace layout described in issue #274.
+    fn fixture_repo_with_shadow_tags() -> (TempDir, Repository) {
+        let td = setup_temp_dir();
+        let repo = Repository::init(td.path()).expect("init repo");
+        {
+            let mut cfg = repo.config().expect("config");
+            cfg.set_str("user.name", "Test User").unwrap();
+            cfg.set_str("user.email", "test@example.com").unwrap();
+        }
+        // Scope all repo-borrowing objects so they drop before `repo` is moved
+        // out on return.
+        {
+            let sig = repo.signature().expect("signature");
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+
+            // Commit A + crate tag
+            let commit_a = repo
+                .commit(Some("HEAD"), &sig, &sig, "feat: initial", &tree, &[])
+                .unwrap();
+            let obj_a = repo.find_object(commit_a, None).unwrap();
+            repo.tag_lightweight("gen-circleci-orb-v0.1.0", &obj_a, false)
+                .unwrap();
+
+            // Commit B (different commit) + workspace shadow tag
+            let parent = repo.find_commit(commit_a).unwrap();
+            let commit_b = repo
+                .commit(Some("HEAD"), &sig, &sig, "chore: ci", &tree, &[&parent])
+                .unwrap();
+            let obj_b = repo.find_object(commit_b, None).unwrap();
+            repo.tag_lightweight("v0.1.0", &obj_b, false).unwrap();
+        }
+
+        (td, repo)
+    }
+
+    /// #274: with a package selected, only that package's `<pkg>-v*` tags are
+    /// treated as release boundaries; the workspace `v*` shadow tag is ignored.
+    #[test]
+    fn test_get_version_tags_package_mode_excludes_shadow() {
+        let (_td, repo) = fixture_repo_with_shadow_tags();
+
+        let mut config = ChangeLogConfig::default();
+        config.set_release_pattern(crate::change_log_config::ReleasePattern::PackagePrefix(
+            "v".to_string(),
+        ));
+
+        let mut builder = ChangeLogBuilder::new();
+        builder
+            .with_config(config)
+            .with_package_name(Some("gen-circleci-orb".to_string()));
+
+        let tags = builder.get_version_tags(&repo).expect("version tags");
+
+        assert_eq!(
+            tags.len(),
+            1,
+            "expected exactly one release tag, got: {:?}",
+            tags.iter().map(|t| t.name()).collect::<Vec<_>>()
+        );
+        assert!(
+            tags[0].name().contains("gen-circleci-orb-v0.1.0"),
+            "expected the crate tag, got `{}`",
+            tags[0].name()
+        );
+    }
+
+    /// #274: workspace-level generation (no package) treats only bare `v*` tags
+    /// as release boundaries; the crate `<pkg>-v*` tag is ignored.
+    #[test]
+    fn test_get_version_tags_workspace_mode_excludes_crate_tag() {
+        let (_td, repo) = fixture_repo_with_shadow_tags();
+
+        // Default config uses ReleasePattern::Prefix("v").
+        let builder = ChangeLogBuilder::new();
+
+        let tags = builder.get_version_tags(&repo).expect("version tags");
+
+        assert_eq!(
+            tags.len(),
+            1,
+            "expected exactly one release tag, got: {:?}",
+            tags.iter().map(|t| t.name()).collect::<Vec<_>>()
+        );
+        assert!(
+            tags[0].name().ends_with("v0.1.0") && !tags[0].name().contains("gen-circleci-orb"),
+            "expected the bare workspace tag, got `{}`",
+            tags[0].name()
+        );
     }
 }

--- a/crates/gen-changelog/src/lib/change_log/tag.rs
+++ b/crates/gen-changelog/src/lib/change_log/tag.rs
@@ -8,11 +8,15 @@ use thiserror::Error;
 
 use crate::change_log_config::ReleasePattern;
 
+// Both patterns are anchored (`^…$`) and are applied to tag names with the
+// `refs/tags/` ref prefix stripped (see `TagBuilder::get_semver`). Anchoring is
+// what keeps a bare `v` prefix from matching the `v<X.Y.Z>` embedded inside a
+// package tag such as `mypkg-v1.2.3` (issue #274).
 pub static PREFIX: Lazy<Regex> = lazy_regex!(
-    r#"(?P<prefix>\w+)(?P<semver>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<pre>-[a-z\.A-Z0-9]+)?(?P<build>\+[0-9A-Za-z-\.]+)?)"#
+    r#"^(?P<prefix>\w+)(?P<semver>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<pre>-[a-z\.A-Z0-9]+)?(?P<build>\+[0-9A-Za-z-\.]+)?)$"#
 );
 pub static PACKAGE_PREFIX: Lazy<Regex> = lazy_regex!(
-    r#"(?P<package>(([-_]?\w+)+))-(?P<prefix>\w+)(?P<semver>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<pre>-[a-z\.A-Z0-9]+)?(?P<build>\+[0-9A-Za-z-\.]+)?)"#
+    r#"^(?P<package>(([-_]?\w+)+))-(?P<prefix>\w+)(?P<semver>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?P<pre>-[a-z\.A-Z0-9]+)?(?P<build>\+[0-9A-Za-z-\.]+)?)$"#
 );
 
 #[derive(Debug, Clone)]
@@ -140,7 +144,10 @@ impl<'a> TagBuilder<'a> {
             "getting semver for {} using the pattern {release_pattern:?}",
             self.name
         );
-        let haystack = self.name.clone();
+        // Match against the short tag name; `tag_foreach` yields full ref names
+        // like `refs/tags/v1.2.3`, and the anchored patterns expect the tag name
+        // to start at the prefix (or package) segment.
+        let haystack = self.name.trim_start_matches("refs/tags/").to_string();
 
         match release_pattern {
             ReleasePattern::Prefix(p) => {
@@ -324,3 +331,56 @@ impl<'a> TagBuilder<'a> {
 //         assert_eq!(tag.id, id);
 //     }
 // }
+
+#[cfg(test)]
+mod regex_tests {
+    //! Anchoring contract for the tag-matching regexes (issue #274).
+    //!
+    //! Names here are already stripped of the `refs/tags/` ref prefix, matching
+    //! what [`TagBuilder::get_semver`] feeds the regexes after trimming.
+    use super::{PACKAGE_PREFIX, PREFIX};
+
+    #[test]
+    fn prefix_matches_bare_version() {
+        let caps = PREFIX.captures("v0.1.2").expect("should match bare v tag");
+        assert_eq!(caps.name("prefix").unwrap().as_str(), "v");
+        assert_eq!(caps.name("semver").unwrap().as_str(), "0.1.2");
+    }
+
+    #[test]
+    fn prefix_matches_pre_release() {
+        let caps = PREFIX
+            .captures("v1.0.0-rc.1")
+            .expect("should match pre-release");
+        assert_eq!(caps.name("prefix").unwrap().as_str(), "v");
+        assert_eq!(caps.name("semver").unwrap().as_str(), "1.0.0-rc.1");
+    }
+
+    #[test]
+    fn prefix_rejects_package_tag() {
+        // The core of #274: a bare `v` prefix must NOT match the `v0.1.2`
+        // embedded inside a crate tag.
+        assert!(
+            PREFIX.captures("gen-circleci-orb-v0.1.2").is_none(),
+            "bare-v PREFIX must not match a package-prefixed tag"
+        );
+    }
+
+    #[test]
+    fn package_prefix_matches_crate_tag() {
+        let caps = PACKAGE_PREFIX
+            .captures("gen-circleci-orb-v0.1.2")
+            .expect("should match crate tag");
+        assert_eq!(caps.name("package").unwrap().as_str(), "gen-circleci-orb");
+        assert_eq!(caps.name("prefix").unwrap().as_str(), "v");
+        assert_eq!(caps.name("semver").unwrap().as_str(), "0.1.2");
+    }
+
+    #[test]
+    fn package_prefix_rejects_bare_version() {
+        assert!(
+            PACKAGE_PREFIX.captures("v0.1.2").is_none(),
+            "package-prefix pattern must not match a bare workspace tag"
+        );
+    }
+}

--- a/crates/gen-changelog/src/lib/change_log_config.rs
+++ b/crates/gen-changelog/src/lib/change_log_config.rs
@@ -586,6 +586,27 @@ impl ChangeLogConfig {
         &self.release_pattern
     }
 
+    /// Sets the release pattern used to identify Git tags as release tags.
+    ///
+    /// The default is [`ReleasePattern::Prefix`] with a `"v"` prefix (matching
+    /// bare workspace tags such as `v1.0.0`). Selecting
+    /// [`ReleasePattern::PackagePrefix`] restricts release boundaries to a
+    /// single package's `<package>-v*` tags, which — combined with
+    /// [`ChangeLogBuilder::with_package_name`](crate::ChangeLogBuilder) — lets a
+    /// per-crate changelog ignore the workspace shadow `v*` tags.
+    ///
+    /// # Arguments
+    ///
+    /// * `pattern` - The release pattern to use
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to self for method chaining
+    pub fn set_release_pattern(&mut self, pattern: ReleasePattern) -> &mut Self {
+        self.release_pattern = pattern;
+        self
+    }
+
     /// Returns a reference to the display sections configuration.
     ///
     /// This determines how many changelog sections will be included in the

--- a/crates/gen-changelog/src/lib/lib.rs
+++ b/crates/gen-changelog/src/lib/lib.rs
@@ -13,6 +13,6 @@ mod package;
 pub(crate) mod test_utils;
 
 pub use change_log::{ChangeLog, ChangeLogBuilder, DEFAULT_CHANGELOG_FILENAME};
-pub use change_log_config::ChangeLogConfig;
+pub use change_log_config::{ChangeLogConfig, ReleasePattern};
 pub use error::Error;
 pub use package::RustPackages;


### PR DESCRIPTION
## Summary

Fixes #274 — per-package changelog duplicating releases in workspaces that carry two version-tag families (a crate tag `<pkg>-v<X.Y.Z>` and a workspace shadow tag `v<X.Y.Z>`) on different commits.

## Root cause

- `PREFIX` in `tag.rs` was **unanchored**, so a bare `v` prefix matched the `v<X.Y.Z>` embedded inside a crate tag like `gen-circleci-orb-v0.1.2`. Both tag families therefore matched the default `ReleasePattern::Prefix("v")`, producing a duplicate (usually empty) section per version.
- The package-prefix machinery (`ReleasePattern::PackagePrefix`, `TagBuilder::set_package`) was **half-built and dead** — nothing ever selected it or set the package, so `--package` only scoped commits, never tags.

## Fix

- **Anchor** `PREFIX`/`PACKAGE_PREFIX` (`^…$`) and match against the tag name with the `refs/tags/` ref prefix stripped, so a bare `v` no longer matches a package-prefixed tag.
- **Complete the package-prefix path**: `--package` now selects `ReleasePattern::PackagePrefix("v")` and threads the package name through the builder via a new `ChangeLogBuilder::with_package_name`, so `set_package` gates tag matching to that package's `<pkg>-v*` family. Workspace-level generation (no `--package`) considers only bare `v*`.

Net: each released version appears exactly once. This unblocks turning on per-crate `CHANGELOG.md` generation in shadow-tag workspaces.

## Tests (RED → GREEN)

- New git-fixture tests in `change_log.rs` build a temp repo with `gen-circleci-orb-v0.1.0` and `v0.1.0` on different commits and assert `get_version_tags` returns exactly one tag in both package mode and workspace mode.
- New anchoring-contract tests in `tag.rs` (`regex_tests`) assert a bare `v` prefix rejects a package tag and vice-versa.
- Both new behavioural tests failed on the unpatched code and pass after the fix.

## Verification

- `cargo test` — 111 lib tests + `cli_tests` (trycmd) green; no snapshot changes (no CLI flags added).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo audit` — clean, no configured ignores.
- `cargo msrv verify` — compatible at declared `rust-version = 1.87`.
- Reproduced against a real shadow-tag workspace (`gen-circleci-orb`): each version now renders once, no empty `Summary:` sections, in both `--package` and workspace modes.

## Notes

- No new CLI flags — the tag family is selected automatically from `--package`, so the existing per-crate release hook works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
