### PR TITLE
test: stop tests writing into the crate dir

### DIFF
--- a/crates/gen-changelog/src/lib/change_log.rs
+++ b/crates/gen-changelog/src/lib/change_log.rs
@@ -43,7 +43,7 @@ static REMOTE: Lazy<Regex> = lazy_regex!(
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use gen_changelog::ChangeLog;
 ///
 /// let changelog = ChangeLog::builder()
@@ -109,7 +109,7 @@ impl ChangeLog {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use gen_changelog::ChangeLog;
     ///
     /// let changelog = ChangeLog::builder().build();
@@ -809,24 +809,19 @@ mod tests {
 
     #[test]
     fn test_changelog_save() {
-        let temp_dir = setup_temp_dir();
-        let temp_path = temp_dir.path();
+        // `save` writes relative to the current directory when no package root
+        // is set, so run inside an isolated temp CWD to avoid writing into the
+        // crate directory.
+        crate::test_utils::with_isolated_cwd(|temp_path| {
+            let changelog = ChangeLog::builder().build();
+            let result = changelog.save(DEFAULT_CHANGELOG_FILENAME);
 
-        // Change to temp directory
-        let original_dir = std::env::current_dir().unwrap();
-        std::env::set_current_dir(temp_path).unwrap();
+            assert!(result.is_ok());
+            assert!(temp_path.join("CHANGELOG.md").exists());
 
-        let changelog = ChangeLog::builder().build();
-        let result = changelog.save(DEFAULT_CHANGELOG_FILENAME);
-
-        // Restore original directory
-        std::env::set_current_dir(original_dir).unwrap();
-
-        assert!(result.is_ok());
-        assert!(temp_path.join("CHANGELOG.md").exists());
-
-        let content = fs::read_to_string(temp_path.join("CHANGELOG.md")).unwrap();
-        assert!(!content.is_empty());
+            let content = fs::read_to_string(temp_path.join("CHANGELOG.md")).unwrap();
+            assert!(!content.is_empty());
+        });
     }
 
     #[test]

--- a/crates/gen-changelog/src/lib/change_log_config.rs
+++ b/crates/gen-changelog/src/lib/change_log_config.rs
@@ -397,7 +397,7 @@ impl ChangeLogConfig {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use gen_changelog::ChangeLogConfig;
     ///
     /// # #[allow(non_snake_case)]
@@ -783,25 +783,17 @@ mod tests {
     #[test]
     fn test_from_file_or_default_no_file() {
         get_test_logger();
-        let dcf = PathBuf::new().join(DEFAULT_CONFIG_FILE);
-        let mut safe_dcf = String::from(DEFAULT_CONFIG_FILE);
-        safe_dcf.push_str("-safe");
-        let safe_dcf = PathBuf::new().join(safe_dcf);
-        let mut renamed = false;
-        if dcf.exists() {
-            let _ = fs::rename(&dcf, &safe_dcf);
-            renamed = true;
-        }
-        // When no config file exists, should return default config
-        let result = ChangeLogConfig::from_file_or_default();
-        if renamed {
-            let _ = fs::rename(&safe_dcf, &dcf);
-        }
-        assert!(result.is_ok());
+        // Run in an empty temp CWD so no default config file is present, rather
+        // than renaming the crate's default config in place.
+        crate::test_utils::with_isolated_cwd(|_| {
+            // When no config file exists, should return default config
+            let result = ChangeLogConfig::from_file_or_default();
+            assert!(result.is_ok());
 
-        let config = result.unwrap();
-        log::debug!("{config:#?}");
-        assert!(matches!(config.display_sections, DisplaySections::All));
+            let config = result.unwrap();
+            log::debug!("{config:#?}");
+            assert!(matches!(config.display_sections, DisplaySections::All));
+        });
     }
 
     #[test]
@@ -820,20 +812,19 @@ cc-types = ["test"]
 "TestGroup" = 10
 "#;
 
-        let (_temp_dir, _file_path) = create_temp_config_file(toml_content);
+        // Create the default config file inside an isolated temp CWD so
+        // `from_file_or_default` reads it there instead of the crate directory.
+        crate::test_utils::with_isolated_cwd(|temp_path| {
+            let default_config_path = temp_path.join(DEFAULT_CONFIG_FILE);
+            fs::write(&default_config_path, toml_content).expect("Failed to write default config");
 
-        // Temporarily create the default config file
-        let default_config_path = PathBuf::from(DEFAULT_CONFIG_FILE);
-        fs::write(&default_config_path, toml_content).expect("Failed to write default config");
+            let result = ChangeLogConfig::from_file_or_default();
+            log::debug!("{result:?}");
 
-        let result = ChangeLogConfig::from_file_or_default();
-        log::debug!("{result:?}");
-        // Clean up
-        let _ = fs::remove_file(default_config_path);
-
-        assert!(result.is_ok());
-        let config = result.unwrap();
-        assert!(matches!(config.display_sections, DisplaySections::One));
+            assert!(result.is_ok());
+            let config = result.unwrap();
+            assert!(matches!(config.display_sections, DisplaySections::One));
+        });
     }
 
     #[test]

--- a/crates/gen-changelog/src/lib/test_utils.rs
+++ b/crates/gen-changelog/src/lib/test_utils.rs
@@ -1,8 +1,59 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard};
+
 use log::LevelFilter;
+use tempfile::TempDir;
 
 pub(crate) fn get_test_logger() {
     let mut builder = env_logger::Builder::new();
     builder.filter(None, LevelFilter::Debug);
     builder.format_timestamp_secs().format_module_path(false);
     let _ = builder.try_init();
+}
+
+/// Process-wide lock serializing tests that change the current directory.
+///
+/// The current directory is process-global, so tests that mutate it (or read
+/// files relative to it) must not run concurrently. Poisoning is recovered from
+/// so a single panicking test does not disable the rest.
+static CWD_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII guard that restores the original working directory on drop.
+struct CwdGuard {
+    _lock: MutexGuard<'static, ()>,
+    original: PathBuf,
+    // Kept alive for the duration of the guard; removed after the CWD is
+    // restored so the temp dir is never the current directory when deleted.
+    _temp: TempDir,
+}
+
+impl Drop for CwdGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+/// Runs `f` inside a fresh temporary directory as the current working
+/// directory, serialized against other current-directory-sensitive tests.
+///
+/// Use this for any test that reads or writes files via a path relative to the
+/// current directory (e.g. [`ChangeLog::save`](crate::ChangeLog) with a bare
+/// filename, or [`ChangeLogConfig::from_file_or_default`](crate::ChangeLogConfig))
+/// so tests never touch files in the crate directory. The original working
+/// directory is restored even if `f` panics.
+pub(crate) fn with_isolated_cwd<T>(f: impl FnOnce(&Path) -> T) -> T {
+    let lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let original = std::env::current_dir().expect("read current dir");
+    let temp = TempDir::new().expect("create temp dir");
+    std::env::set_current_dir(temp.path()).expect("set current dir to temp");
+
+    let guard = CwdGuard {
+        _lock: lock,
+        original,
+        _temp: temp,
+    };
+    // Resolve the temp path through the guard so the borrow is valid for `f`.
+    let temp_path = guard._temp.path().to_path_buf();
+    f(&temp_path)
+    // `guard` drops here: CWD restored, then temp dir removed, then lock freed.
 }


### PR DESCRIPTION
## Summary

`cargo test` was corrupting the tracked `crates/gen-changelog/CHANGELOG.md` and `my-config.toml` — every test run left the working tree dirty. (Noticed while working on #274/#275.)

## Root cause

Two categories of tests wrote to paths relative to the current directory, which resolves to the crate directory during `cargo test`:

1. **Executed doctests** — three `///` examples ran `.save("CHANGELOG.md")` / `.save(Some("my-config.toml"))` at the top level (or inside a `# fn main`), so rustdoc actually performed the writes into the crate dir:
   - `ChangeLog` struct example and `ChangeLog::save` example (both wrote `CHANGELOG.md`)
   - `ChangeLogConfig::save` example (wrote `my-config.toml`)
2. **Unit tests** — `test_changelog_save` and the two `from_file_or_default` tests mutated the process-wide current directory (and one wrote a default config file into the crate dir) without isolation. Besides the residue, this is unsafe under parallel test execution since the CWD is process-global.

## Fix

- Marked the three file-writing doctests `no_run` — they still compile (so the API is doc-checked) but no longer execute the write.
- Added a `with_isolated_cwd` helper in `test_utils` that serializes current-directory changes behind a mutex and runs the closure inside a fresh `TempDir`, restoring the original directory on drop (even on panic).
- Moved `test_changelog_save`, `test_from_file_or_default_no_file`, and `test_from_file_or_default_with_file` onto the helper, removing the ad-hoc `set_current_dir` / rename-in-place / crate-dir writes.

## Verification

- Before: `cargo test` → `git status` shows `CHANGELOG.md` and `my-config.toml` modified.
- After: `cargo test` (111 lib tests + doctests + `cli_tests`) passes and `git status` is **clean**.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo audit`, and `cargo msrv verify` (rust-version 1.87) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
