### PR TITLE
fix: drop redundant borrow in panic! arg

### DIFF
--- a/crates/gen-changelog/src/cli/generate_cli.rs
+++ b/crates/gen-changelog/src/cli/generate_cli.rs
@@ -52,7 +52,7 @@ impl GenerateCli {
         let repo_dir = PathBuf::new().join(&self.repository_dir);
         log::debug!("{}", repo_dir.display());
         let repository = Repository::open(&repo_dir)
-            .unwrap_or_else(|_| panic!("unable to open the repository at {}", &repo_dir.display()));
+            .unwrap_or_else(|_| panic!("unable to open the repository at {}", repo_dir.display()));
 
         let rust_package = if self.package.is_some() {
             let packages = RustPackages::new(&repo_dir)?;


### PR DESCRIPTION
## Summary

The rolling CI toolchain's Clippy (`toolkit/idiomatic_rust`) fails with `useless_borrows_in_formatting` on `&repo_dir.display()` inside the `panic!` format argument in `generate_cli.rs` — the `Display` value is borrowed needlessly. Surfaced on the `renovate/toolkit-6.x` (toolkit v6.6.2) pipeline, but it's a pre-existing lint the newer compiler now enforces.

## Fix

Drop the `&`:

```rust
panic!("unable to open the repository at {}", repo_dir.display())
```

## Verification

- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, full `cargo test`, `cargo audit`, and `cargo msrv verify` (rust-version 1.87) all pass.
- Broad scan found no other `&`-in-format-argument instances in the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)