### PR TITLE
fix: anchor package changelog path to repo root

### DIFF
--- a/crates/gen-changelog/src/cli/generate_cli.rs
+++ b/crates/gen-changelog/src/cli/generate_cli.rs
@@ -54,6 +54,12 @@ impl GenerateCli {
         let repository = Repository::open(&repo_dir)
             .unwrap_or_else(|_| panic!("unable to open the repository at {}", repo_dir.display()));
 
+        // Anchor output to an absolute repository path so the changelog is
+        // written to the right place regardless of the working directory the
+        // command runs from (e.g. a crate dir under a release hook) — issue
+        // #284. Fall back to the given path if it cannot be canonicalised.
+        let repo_root = repo_dir.canonicalize().unwrap_or_else(|_| repo_dir.clone());
+
         let rust_package = if self.package.is_some() {
             let packages = RustPackages::new(&repo_dir)?;
             log::debug!("{packages:?}");
@@ -81,13 +87,15 @@ impl GenerateCli {
             .with_summary_flag(self.display_summaries)
             .with_rust_package(rust_package)
             .with_package_name(self.package.clone())
+            .with_repository_root(Some(repo_root))
             .walk_repository(&repository)
             .unwrap()
             .update_unreleased_to_next_version(self.next_version.as_ref())
             .build();
 
         if !self.no_save {
-            let _ = change_log.save(&self.name);
+            // Propagate save failures instead of silently exiting 0 (issue #284).
+            change_log.save(&self.name)?;
         }
         if self.show {
             println!("{change_log}");

--- a/crates/gen-changelog/src/lib/change_log.rs
+++ b/crates/gen-changelog/src/lib/change_log.rs
@@ -190,6 +190,10 @@ pub struct ChangeLogBuilder {
     /// Name of the package being generated for, used to restrict release tags
     /// to that package's `<package>-v*` family (issue #274).
     package_name: Option<String>,
+    /// Absolute path to the repository working directory. The changelog output
+    /// path is anchored to this so `save` is independent of the current working
+    /// directory (issue #284).
+    repository_root: Option<PathBuf>,
 }
 
 impl Debug for ChangeLogBuilder {
@@ -225,6 +229,7 @@ impl ChangeLogBuilder {
             include_merge_commits: bool::default(),
             config: ChangeLogConfig::default(),
             package_name: None,
+            repository_root: None,
         }
     }
 
@@ -245,11 +250,21 @@ impl ChangeLogBuilder {
         }
     }
 
+    /// Computes the directory the changelog is written into.
+    ///
+    /// The package root (`rp.root`) is stored relative to the repository (e.g.
+    /// `crates/foo`), so it is anchored to the repository working directory when
+    /// known. This keeps `ChangeLog::save` independent of the current working
+    /// directory — e.g. a per-crate release hook that runs from the crate
+    /// directory still writes to `<repo>/crates/foo/CHANGELOG.md` (issue #284).
+    ///
+    /// When the repository root is unknown, falls back to the previous
+    /// CWD-relative behaviour.
     fn package_root(&self) -> PathBuf {
-        if let Some(rp) = &self.rust_package {
-            PathBuf::new().join(rp.root.clone())
-        } else {
-            PathBuf::new()
+        let base = self.repository_root.clone().unwrap_or_default();
+        match &self.rust_package {
+            Some(rp) => base.join(&rp.root),
+            None => base,
         }
     }
 
@@ -353,6 +368,19 @@ impl ChangeLogBuilder {
         self
     }
 
+    /// Sets the repository working directory that the changelog output path is
+    /// anchored to.
+    ///
+    /// Prefer an absolute path so [`ChangeLog::save`] is independent of the
+    /// current working directory (issue #284). When left unset,
+    /// [`walk_repository`](Self::walk_repository) populates it from the
+    /// repository's working directory; if that is also unavailable the output
+    /// path falls back to being relative to the current directory.
+    pub fn with_repository_root(&mut self, root: Option<PathBuf>) -> &mut Self {
+        self.repository_root = root;
+        self
+    }
+
     /// Sets whether merge commits should be included in the changelog.
     ///
     /// Merge commits (commits with two or more parents) are excluded by
@@ -402,6 +430,15 @@ impl ChangeLogBuilder {
     /// # }
     /// ```
     pub fn walk_repository(&mut self, repository: &Repository) -> Result<&mut Self, Error> {
+        // Anchor the output path to the repository so `save` does not depend on
+        // the current working directory (issue #284). An explicitly configured
+        // root takes precedence.
+        if self.repository_root.is_none() {
+            if let Some(workdir) = repository.workdir() {
+                self.repository_root = Some(workdir.to_path_buf());
+            }
+        }
+
         self.get_remote_details(repository)?;
 
         let version_tags = self.get_version_tags(repository)?;
@@ -822,6 +859,39 @@ mod tests {
             let content = fs::read_to_string(temp_path.join("CHANGELOG.md")).unwrap();
             assert!(!content.is_empty());
         });
+    }
+
+    /// #284: with a package set, `save` must write under the repository root
+    /// (`<repo>/<package-root>/<name>`), not relative to the current working
+    /// directory — otherwise a per-crate release hook run from the crate dir
+    /// writes to the wrong path (or nowhere).
+    #[test]
+    fn test_save_package_anchored_to_repository_root() {
+        let repo = setup_temp_dir();
+        let repo_root = repo.path().to_path_buf();
+        std::fs::create_dir_all(repo_root.join("crates/foo")).unwrap();
+
+        let mut builder = ChangeLogBuilder::new();
+        builder
+            .with_header("Foo", &["desc"])
+            .with_rust_package(Some(RustPackage {
+                root: "crates/foo".to_string(),
+                dependencies: Vec::new(),
+            }))
+            .with_repository_root(Some(repo_root.clone()));
+        let changelog = builder.build();
+
+        // Save from an unrelated working directory.
+        crate::test_utils::with_isolated_cwd(|_| {
+            changelog.save("CHANGELOG.md").expect("save should succeed");
+        });
+
+        let expected = repo_root.join("crates/foo/CHANGELOG.md");
+        assert!(
+            expected.exists(),
+            "expected changelog at {} (anchored to repo root), not relative to CWD",
+            expected.display()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #284 — `gen-changelog generate --package <name>` silently wrote the changelog to the wrong path (or nowhere) when run from a subdirectory such as the crate directory, and the save error was discarded so the command still exited `0`.

## Root cause

`RustPackage.root` is stored **relative to the repository** (e.g. `crates/foo`) — and must stay that way, since commit-file matching (`is_commit_to_package_file`) uses `path.starts_with(root)` against repo-relative git paths. But `ChangeLog::save` resolved `pkg_root.join(name)` relative to the **current working directory**. So:

- CWD = repo root → `crates/foo/CHANGELOG.md` ✅
- CWD = crate dir (as under a cargo-release pre-release hook) → `crates/foo/crates/foo/CHANGELOG.md`, `fs::write` errors, and `let _ = change_log.save(...)` swallowed it → **exit 0, no file written** ❌

## Fix

- **Anchor the output directory to the repository working directory.** `ChangeLogBuilder` gains `with_repository_root`; `walk_repository` populates it from `Repository::workdir()` when not set explicitly; and the CLI passes the **canonicalised** `--repository-dir`. `package_root` now joins the repo-relative package root onto that absolute base, so `save` is independent of the CWD. `rp.root` itself stays repository-relative.
- **Propagate the save error** in `generate` (`change_log.save(&self.name)?`) instead of discarding it, so a failed write surfaces (non-zero exit) rather than exiting `0`.

When the repository root is unknown, behaviour falls back to the previous CWD-relative path — no change for existing callers running from the repo root.

## Tests (RED → GREEN)

- New unit test `test_save_package_anchored_to_repository_root` builds a changelog for a package rooted at `crates/foo`, saves it from an unrelated (isolated) working directory, and asserts the file lands at `<repo>/crates/foo/CHANGELOG.md`. It failed before the fix (missing anchoring API) and passes after.

## Verification

- Reproduced the exact issue scenario against a real workspace (`gen-circleci-orb`): from the crate subdirectory with `--repository-dir ../..`, the changelog is now written to `<repo>/crates/gen-circleci-orb/…` (populated), where before it wrote nothing.
- Confirmed a failing save now exits non-zero with the error printed, instead of exiting `0` silently.
- `cargo test` (112 lib + doctests + `cli_tests`), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo audit`, and `cargo msrv verify` (rust-version 1.87) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
