### PR TITLE
chore: remove redundant toolkit/label job

### DIFF
--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -5,8 +5,8 @@ version: 2.1
 # so the PRLOG update commit does not re-trigger this workflow.
 #
 # Workflow:
-#   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main
-#   label         - labels the next queued Renovate PR so it is rebased and runs
+#   update_prlog  - adds merged PR entry to PRLOG.md, commits and pushes to main,
+#                   then labels the next queued Renovate PR (run_label: true default)
 
 parameters:
   min-rust-version:
@@ -33,7 +33,3 @@ workflows:
           pcu_from_merge: --from-merge
           update_pcu: << pipeline.parameters.update_pcu >>
           pcu_verbosity: "-vvv"
-      - toolkit/label:
-          context: pcu-app
-          requires:
-            - update-prlog-on-main


### PR DESCRIPTION
`toolkit/update_prlog` labels the oldest open Renovate PR by default (`run_label: true`), so the standalone `toolkit/label` job double-labeled the queue. Removed it and updated the header comment to the migrated wording (labeling built into `update_prlog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)